### PR TITLE
Add /proc/smolvm-fsnotify to inject host-originated fsnotify events

### DIFF
--- a/patches/0023-smolvm-fsnotify-inject.patch
+++ b/patches/0023-smolvm-fsnotify-inject.patch
@@ -1,0 +1,125 @@
+smolvm: inject fsnotify events for host-originated file changes
+
+virtiofs does not deliver host-side file changes to the guest as
+fsnotify/inotify events, so inotify-based hot-reload never fires on host
+edits. Add /proc/smolvm-fsnotify: writing "<mask_hex> <path>" fires the
+matching fsnotify events on the guest inode, so guest watchers wake as if
+the change happened locally. Driven by the smolvm host FS watcher via the
+guest agent.
+
+Signed-off-by: smolvm <noreply@smolvm>
+---
+diff --git a/fs/notify/Makefile b/fs/notify/Makefile
+--- a/fs/notify/Makefile
++++ b/fs/notify/Makefile
+@@ -2,6 +2,7 @@
+ obj-$(CONFIG_FSNOTIFY)		+= fsnotify.o notification.o group.o mark.o \
+ 				   fdinfo.o
+ 
++obj-$(CONFIG_FSNOTIFY)		+= smolvm_inject.o
+ obj-y			+= dnotify/
+ obj-y			+= inotify/
+ obj-y			+= fanotify/
+diff --git a/fs/notify/smolvm_inject.c b/fs/notify/smolvm_inject.c
+new file mode 100644
+--- /dev/null
++++ b/fs/notify/smolvm_inject.c
+@@ -0,0 +1,98 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * smolvm_inject.c - inject fsnotify events for host-originated file changes.
++ *
++ * virtiofs (FUSE) does not propagate host-side file changes into the guest as
++ * fsnotify/inotify events, so inotify-based hot-reload (Vite, webpack, nodemon)
++ * never fires when a file is edited on the host. smolvm watches the host mount
++ * source and, via the guest agent, writes "<mask_hex> <path>" to
++ * /proc/smolvm-fsnotify; this fires the matching fsnotify events on the guest
++ * inode so guest watchers wake up exactly as if the change happened locally.
++ *
++ * The write format is one event per write():
++ *     "<mask_hex> <absolute_guest_path>\n"
++ * where mask is an FS_* bitmask (see include/linux/fsnotify_backend.h), e.g.
++ * FS_MODIFY (0x2) or FS_CREATE (0x100). fsnotify_dentry() propagates the event
++ * to the inode's own watchers and, via fsnotify_parent(), to a watcher on the
++ * containing directory (with the child name) - covering both file and dir
++ * watches from a single call.
++ *
++ * Interface is write-only and root-only (0200). The guest is single-tenant and
++ * the agent runs as root, so no finer capability check is needed.
++ */
++#include <linux/kernel.h>
++#include <linux/init.h>
++#include <linux/proc_fs.h>
++#include <linux/uaccess.h>
++#include <linux/namei.h>
++#include <linux/fsnotify.h>
++#include <linux/fs.h>
++#include <linux/slab.h>
++#include <linux/limits.h>
++
++/* Bound a single request: an FS_* mask in hex plus one absolute path. */
++#define SMOLVM_FSNOTIFY_MAX (PATH_MAX + 32)
++
++static ssize_t smolvm_fsnotify_write(struct file *file, const char __user *ubuf,
++				     size_t count, loff_t *ppos)
++{
++	char *kbuf, *pathstr;
++	struct path path;
++	u32 mask;
++	int ret;
++
++	if (count == 0 || count >= SMOLVM_FSNOTIFY_MAX)
++		return -EINVAL;
++
++	kbuf = memdup_user_nul(ubuf, count);
++	if (IS_ERR(kbuf))
++		return PTR_ERR(kbuf);
++
++	/* Trim a trailing newline so the path token stays clean. */
++	if (kbuf[count - 1] == '\n')
++		kbuf[count - 1] = '\0';
++
++	/* Split "<mask_hex> <path>" on the first space. */
++	pathstr = strchr(kbuf, ' ');
++	if (!pathstr) {
++		ret = -EINVAL;
++		goto out;
++	}
++	*pathstr++ = '\0';
++	while (*pathstr == ' ' || *pathstr == '\t')
++		pathstr++;
++	if (*pathstr == '\0') {
++		ret = -EINVAL;
++		goto out;
++	}
++
++	if (kstrtou32(kbuf, 16, &mask)) {
++		ret = -EINVAL;
++		goto out;
++	}
++
++	ret = kern_path(pathstr, LOOKUP_FOLLOW, &path);
++	if (ret)
++		goto out;
++
++	fsnotify_dentry(path.dentry, mask);
++	path_put(&path);
++
++	ret = count;
++out:
++	kfree(kbuf);
++	return ret;
++}
++
++static const struct proc_ops smolvm_fsnotify_ops = {
++	.proc_write	= smolvm_fsnotify_write,
++	.proc_lseek	= noop_llseek,
++};
++
++static int __init smolvm_fsnotify_init(void)
++{
++	proc_create("smolvm-fsnotify", 0200, NULL, &smolvm_fsnotify_ops);
++	return 0;
++}
++
++late_initcall(smolvm_fsnotify_init);


### PR DESCRIPTION
virtiofs serves file contents to the guest but does not deliver host-side change notifications, so inotify-based hot-reload (Vite, webpack, nodemon) never fires when a mounted file is edited on the host.

This adds fs/notify/smolvm_inject.c, exposing a write-only, root-only /proc/smolvm-fsnotify. Writing "<mask_hex> <path>" resolves the path with kern_path() and calls fsnotify_dentry(), which fires the event on the inode and propagates to the parent directory's watchers with the child name — so both file and directory watches fire. Because smolvm binds the same virtiofs inode into the container, a watcher inside the container wakes up exactly as if the change happened locally.

The smolvm host watcher detects the change and the guest agent drives this interface. Validated on macOS end to end: editing a mounted file on the host fires MODIFY/CREATE inside the container.