### PR TITLE
Bump kernel to 6.12.94 (6.12.91 rotated off the CDN)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KERNEL_VERSION = linux-6.12.91
+KERNEL_VERSION = linux-6.12.94
 KERNEL_REMOTE = https://cdn.kernel.org/pub/linux/kernel/v6.x/$(KERNEL_VERSION).tar.xz
 KERNEL_TARBALL = tarballs/$(KERNEL_VERSION).tar.xz
 KERNEL_SOURCES = $(KERNEL_VERSION)


### PR DESCRIPTION
kernel.org's CDN only serves the current point release per series. linux-6.12.91.tar.xz now returns 404, so libkrunfw can no longer be built from source (the tarball is downloaded, not committed). Bump KERNEL_VERSION to the current longterm 6.12.94 so fresh builds work again. Config forward-ports via the existing build-time olddefconfig step; the /proc/smolvm-fsnotify patch applies unchanged (fs/notify/Makefile is stable across 6.12.x point releases).