### PR TITLE
Make kernel tarball download follow redirects + fail on HTTP errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ all: $(KRUNFW_BINARY_$(OS))
 
 $(KERNEL_TARBALL):
 	@mkdir -p tarballs
-	curl $(KERNEL_REMOTE) -o $(KERNEL_TARBALL)
+	curl -fL $(KERNEL_REMOTE) -o $(KERNEL_TARBALL)
 
 $(KERNEL_SOURCES): $(KERNEL_TARBALL)
 	tar xf $(KERNEL_TARBALL)


### PR DESCRIPTION
The Makefile's `curl $(KERNEL_REMOTE) -o ...` has no -f/-L, so a redirect or 404 is saved as the tarball and the next tar dies with 'This does not look like a tar archive'. Add -fL: fail the build on a bad HTTP status, follow the CDN redirect to the real tarball.