### PR TITLE
Fetch kernel source from git.kernel.org snapshots, not the rotating CDN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 KERNEL_VERSION = linux-6.12.94
-KERNEL_REMOTE = https://cdn.kernel.org/pub/linux/kernel/v6.x/$(KERNEL_VERSION).tar.xz
+KERNEL_REMOTE = https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/snapshot/$(KERNEL_VERSION).tar.gz
 KERNEL_TARBALL = tarballs/$(KERNEL_VERSION).tar.xz
 KERNEL_SOURCES = $(KERNEL_VERSION)
 KERNEL_PATCHES = $(shell find patches/ -name "0*.patch" | sort)


### PR DESCRIPTION
cdn.kernel.org/pub/linux/kernel/v6.x/ serves only the single latest point release per series and rotates it weekly, so any pinned KERNEL_VERSION eventually 404s (this is why 6.12.91 and 6.12.94 both fail to download). git.kernel.org keeps every tag forever; its snapshot tarball extracts to the same linux-<ver>/ directory and tar auto-detects the gzip stream, so builds are reproducible for any pinned version.