### PR TITLE
Bump guest kernel to 6.12.95 (current 6.12 longterm)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KERNEL_VERSION = linux-6.12.94
+KERNEL_VERSION = linux-6.12.95
 KERNEL_REMOTE = https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/snapshot/$(KERNEL_VERSION).tar.gz
 KERNEL_TARBALL = tarballs/$(KERNEL_VERSION).tar.xz
 KERNEL_SOURCES = $(KERNEL_VERSION)


### PR DESCRIPTION
Refreshes the libkrunfw guest kernel from 6.12.94 to 6.12.95, the current 6.12 longterm point release (published 2026-07-04). Routine guest-kernel hygiene — stays on the 6.12 LTS line so all 33 patches (TSI, vsock-dgram, fsnotify-inject, overlayfs, arm64 memory-model, virtio_rtc) continue to apply. CI validates the download + patch-apply + build for x86_64 and aarch64.