### PR TITLE
Add Landlock to the active LSM list in the Windows guest kernel so it is enabled at boot

### DIFF
--- a/config-libkrunfw-windows_x86_64
+++ b/config-libkrunfw-windows_x86_64
@@ -1807,7 +1807,7 @@ CONFIG_SECURITY_LANDLOCK=y
 # CONFIG_INTEGRITY is not set
 # CONFIG_DEFAULT_SECURITY_SELINUX is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="lockdown,yama,loadpin,safesetid,integrity,selinux,bpf"
+CONFIG_LSM="landlock,lockdown,yama,loadpin,safesetid,integrity,selinux,bpf"
 
 #
 # Kernel hardening options


### PR DESCRIPTION
The Windows guest config enables CONFIG_SECURITY_LANDLOCK but pins an explicit CONFIG_LSM that omitted landlock, so the module was compiled yet never activated (the running kernel showed only capability and selinux). The x86_64 and aarch64 configs carry no explicit CONFIG_LSM and inherit the kernel default that already lists landlock first, so this aligns Windows with them by adding landlock to the front of its list.